### PR TITLE
Meteor 1.6 support (mini-files file location)

### DIFF
--- a/env-settings.js
+++ b/env-settings.js
@@ -1,7 +1,7 @@
 // use for file access
 var fs = Npm.require('fs');
 // using this meteor lib, gives secure access to folder structure
-var files = Npm.require("./mini-files");
+var files = Npm.require("../../mini-files.js");
 
 // save reference to serverDir
 var serverDir = files.pathResolve(__meteor_bootstrap__.serverDir);


### PR DESCRIPTION
This PR makes a small change to the `env-settings.json` file (location of the `mini-files` file) to allow developers to use this package with Meteor 1.6. Based on the [issue on Meteor repo](https://github.com/meteor/meteor/issues/9317).